### PR TITLE
Bugfix: Global README link correction for all chapters and test sets

### DIFF
--- a/C001_Introduction/README.md
+++ b/C001_Introduction/README.md
@@ -5,8 +5,8 @@
 
 ## Useful Links:
 
-- [Introduction to C](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C001_Introduction/CHAPTER_0_INTRODUCTION.pdf)
-- [Chapter 1 Notes](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C001_Introduction/CHAPTER_1.pdf)
+- [Introduction to C](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C001_Introduction/CHAPTER_0_INTRODUCTION.pdf)
+- [Chapter 1 Notes](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C001_Introduction/CHAPTER_1.pdf)
 
 *Happy Learning!*
 

--- a/C001_Test_Set/README.md
+++ b/C001_Test_Set/README.md
@@ -5,7 +5,7 @@
 
 ## Useful Links:
 
-- [Chapter 1 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C001_Test_Set/CHAPTER_1_PRACTICE_SET.pdf)
+- [Chapter 1 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C001_Test_Set/CHAPTER_1_PRACTICE_SET.pdf)
 
 *Happy Learning!*
 


### PR DESCRIPTION
This PR fixes broken links in the README.md files of all subdirectories by replacing `/tree/main/` with `/blob/main/`. This ensures direct file access on GitHub instead of folder views.

- Root README is untouched.
- All chapter and test set folders updated.
- Ensures consistency across branches.

Fixes: Broken navigation issue in GitHub UI.
