### PR TITLE
Bugfix: Global README link correction for all chapters and test sets

### DIFF
--- a/C002_Operators_And_Variables/README.md
+++ b/C002_Operators_And_Variables/README.md
@@ -5,8 +5,8 @@
 
 ## Useful Links:
 
-- [Chapter 2 Notes 1](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C002_Operators_And_Variables/CHAPTER_2_INSTRUCTIONS_AND_OPERATORS.pdf)
-- [Chapter 2 Notes 2](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C002_Operators_And_Variables/C2_NOTES.md)
+- [Chapter 2 Notes 1](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C002_Operators_And_Variables/CHAPTER_2_INSTRUCTIONS_AND_OPERATORS.pdf)
+- [Chapter 2 Notes 2](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C002_Operators_And_Variables/C2_NOTES.md)
 
 *Happy Learning!*
 

--- a/C002_Test_Set/README.md
+++ b/C002_Test_Set/README.md
@@ -5,9 +5,9 @@
 
 ## Useful Links:
 
-- [Chapter 2 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C002_Test_Set/CHAPTER_2_PRACTICE_SET.pdf)
-- [Chapter 2 Test Set Notes](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C002_Test_Set/PC2_NOTES.md)
-- [Type Promotion Flowchart](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C002_Test_Set/PC2_TYPE_PROMOTION_FLOWCHART.png)
+- [Chapter 2 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C002_Test_Set/CHAPTER_2_PRACTICE_SET.pdf)
+- [Chapter 2 Test Set Notes](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C002_Test_Set/PC2_NOTES.md)
+- [Type Promotion Flowchart](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C002_Test_Set/PC2_TYPE_PROMOTION_FLOWCHART.png)
 
 *Happy Learning!*
 


### PR DESCRIPTION
This PR fixes broken links in the README.md files of all subdirectories by replacing `/tree/main/` with `/blob/main/`. This ensures direct file access on GitHub instead of folder views.

- Root README is untouched.
- All chapter and test set folders updated.
- Ensures consistency across branches.

Fixes: Broken navigation issue in GitHub UI.
