### PR TITLE
Bugfix: Global README link correction for all chapters and test sets

### DIFF
--- a/C003_Conditional_Statements/README.md
+++ b/C003_Conditional_Statements/README.md
@@ -5,7 +5,7 @@
 
 ## Useful Links:
 
-- [Chapter 3 Notes](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C003_Conditional_Statements/CHAPTER_3_CONDITIONAL_INSTRUCTIONS.pdf)
+- [Chapter 3 Notes](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C003_Conditional_Statements/CHAPTER_3_CONDITIONAL_INSTRUCTIONS.pdf)
 
 *Happy Learning!*
 

--- a/C003_Test_Set/README.md
+++ b/C003_Test_Set/README.md
@@ -5,7 +5,7 @@
 
 ## Useful Links:
 
-- [Chapter 3 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C003_Test_Set/CHAPTER_3_PRACTICE_SET.pdf)
+- [Chapter 3 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C003_Test_Set/CHAPTER_3_PRACTICE_SET.pdf)
 
 *Happy Learning!*
 


### PR DESCRIPTION
This PR fixes broken links in the README.md files of all subdirectories by replacing `/tree/main/` with `/blob/main/`. This ensures direct file access on GitHub instead of folder views.

- Root README is untouched.
- All chapter and test set folders updated.
- Ensures consistency across branches.

Fixes: Broken navigation issue in GitHub UI.