### PR TITLE
Bugfix: Global README link correction for all chapters and test sets

### DIFF
--- a/C004_Loops/README.md
+++ b/C004_Loops/README.md
@@ -5,8 +5,8 @@
 
 ## Useful Links:
 
-- [Chapter 4 Notes 1](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C004_Loops/CHAPTER_4_LOOP_CONTROL_INSTRUCTIONS.pdf)
-- [Chapter 4 Notes 2](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C004_Loops/C4_LOOPS_NOTES.md)
+- [Chapter 4 Notes 1](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C004_Loops/CHAPTER_4_LOOP_CONTROL_INSTRUCTIONS.pdf)
+- [Chapter 4 Notes 2](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C004_Loops/C4_LOOPS_NOTES.md)
 
 *Happy Learning!*
 

--- a/C004_Test_Set/README.md
+++ b/C004_Test_Set/README.md
@@ -5,7 +5,7 @@
 
 ## Useful Links:
 
-- [Chapter 4 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C004_Test_Set/CHAPTER_4_PRACTICE_SET.pdf)
+- [Chapter 4 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C004_Test_Set/CHAPTER_4_PRACTICE_SET.pdf)
 
 *Happy Learning!*
 


### PR DESCRIPTION
This PR fixes broken links in the README.md files of all subdirectories by replacing `/tree/main/` with `/blob/main/`. This ensures direct file access on GitHub instead of folder views.

- Root README is untouched.
- All chapter and test set folders updated.
- Ensures consistency across branches.

Fixes: Broken navigation issue in GitHub UI.