### PR TITLE
Bugfix: Global README link correction for all chapters and test sets

### DIFF
--- a/C005_Functions_And_Recursion/README.md
+++ b/C005_Functions_And_Recursion/README.md
@@ -5,8 +5,8 @@
 
 ## Useful Links:
 
-- [Chapter 5 Notes 1](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C005_Functions_And_Recursion/CHAPTER_5_FUNCTIONS_AND_RECURSION.pdf)
-- [Chapter 5 Notes 2](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C005_Functions_And_Recursion/C5_FACTORIAL_BY_RECURSION.md)
+- [Chapter 5 Notes 1](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C005_Functions_And_Recursion/CHAPTER_5_FUNCTIONS_AND_RECURSION.pdf)
+- [Chapter 5 Notes 2](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C005_Functions_And_Recursion/C5_FACTORIAL_BY_RECURSION.md)
 
 *Happy Learning!*
 

--- a/C005_Test_Set/README.md
+++ b/C005_Test_Set/README.md
@@ -5,8 +5,8 @@
 
 ## Useful Links:
 
-- [Chapter 5 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C005_Test_Set/CHAPTER_5_PRACTICE_SET.pdf)
-- [Chapter 5 Test Set Notes](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C005_Test_Set/CP5_Q4RECURSION.md)
+- [Chapter 5 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C005_Test_Set/CHAPTER_5_PRACTICE_SET.pdf)
+- [Chapter 5 Test Set Notes](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C005_Test_Set/CP5_Q4RECURSION.md)
 
 *Happy Learning!*
 


### PR DESCRIPTION
This PR fixes broken links in the README.md files of all subdirectories by replacing `/tree/main/` with `/blob/main/`. This ensures direct file access on GitHub instead of folder views.

- Root README is untouched.
- All chapter and test set folders updated.
- Ensures consistency across branches.

Fixes: Broken navigation issue in GitHub UI.