### PR TITLE
Bugfix: Global README link correction for all chapters and test sets

### DIFF
--- a/C006_Pointers/README.md
+++ b/C006_Pointers/README.md
@@ -5,7 +5,7 @@
 
 ## Useful Links:
 
-- [Chapter 6 Notes](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C006_Pointers/CHAPTER_6_POINTERS.pdf)
+- [Chapter 6 Notes](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C006_Pointers/CHAPTER_6_POINTERS.pdf)
 
 *Happy Learning!*
 

--- a/C006_Test_Set/README.md
+++ b/C006_Test_Set/README.md
@@ -5,7 +5,7 @@
 
 ## Useful Links:
 
-- [Chapter 6 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C006_Test_Set/CHAPTER_6_PRACTICE_SET.pdf)
+- [Chapter 6 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C006_Test_Set/CHAPTER_6_PRACTICE_SET.pdf)
 
 *Happy Learning!*
 


### PR DESCRIPTION
This PR fixes broken links in the README.md files of all subdirectories by replacing `/tree/main/` with `/blob/main/`. This ensures direct file access on GitHub instead of folder views.

- Root README is untouched.
- All chapter and test set folders updated.
- Ensures consistency across branches.

Fixes: Broken navigation issue in GitHub UI.