### PR TITLE
Bugfix: Global README link correction for all chapters and test sets

### DIFF
--- a/C007_Arrays/README.md
+++ b/C007_Arrays/README.md
@@ -5,9 +5,9 @@
 
 ## Useful Links:
 
-- [Chapter 7 Notes](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C007_Arrays/CHAPTER_7.pdf)
-- [Chapter 7 Array Notes](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C007_Arrays/C7_ARR_NOTES.md)
-- [Chapter 7 Size Notes](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C007_Arrays/C7_SIZE_NOTES.md)
+- [Chapter 7 Notes](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C007_Arrays/CHAPTER_7.pdf)
+- [Chapter 7 Array Notes](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C007_Arrays/C7_ARR_NOTES.md)
+- [Chapter 7 Size Notes](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C007_Arrays/C7_SIZE_NOTES.md)
 
 *Happy Learning!*
 

--- a/C007_Test_Set/README.md
+++ b/C007_Test_Set/README.md
@@ -5,8 +5,8 @@
 
 ## Useful Links:
 
-- [Chapter 7 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C007_Test_Set/CHAPTER_7_PRACTICE_SET.pdf)
-- [Chapter 7 Test Set Notes](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C007_Test_Set/CP7_NOTES.md)
+- [Chapter 7 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C007_Test_Set/CHAPTER_7_PRACTICE_SET.pdf)
+- [Chapter 7 Test Set Notes](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C007_Test_Set/CP7_NOTES.md)
 
 *Happy Learning!*
 


### PR DESCRIPTION
This PR fixes broken links in the README.md files of all subdirectories by replacing `/tree/main/` with `/blob/main/`. This ensures direct file access on GitHub instead of folder views.

- Root README is untouched.
- All chapter and test set folders updated.
- Ensures consistency across branches.

Fixes: Broken navigation issue in GitHub UI.