### PR TITLE
Bugfix: Global README link correction for all chapters and test sets

### DIFF
--- a/C008_Strings/README.md
+++ b/C008_Strings/README.md
@@ -5,8 +5,8 @@
 
 ## Useful Links:
 
-- [Chapter 8 Notes 1](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C008_Strings/CHAPTER_8_STRINGS.pdf)
-- [Chapter 8 Notes 2](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C008_Strings/C8_STRING_NOTES.md)
+- [Chapter 8 Notes 1](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C008_Strings/CHAPTER_8_STRINGS.pdf)
+- [Chapter 8 Notes 2](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C008_Strings/C8_STRING_NOTES.md)
 
 *Happy Learning!*
 

--- a/C008_Test_Set/README.md
+++ b/C008_Test_Set/README.md
@@ -5,8 +5,8 @@
 
 ## Useful Links:
 
-- [Chapter 8 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C008_Test_Set/CHAPTER_8_PRACTICE_SET.pdf)
-- [Chapter 8 Test Set Notes](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C008_Test_Set/CP8_NOTES.md)
+- [Chapter 8 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C008_Test_Set/CHAPTER_8_PRACTICE_SET.pdf)
+- [Chapter 8 Test Set Notes](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C008_Test_Set/CP8_NOTES.md)
 
 *Happy Learning!*
 


### PR DESCRIPTION
This PR fixes broken links in the README.md files of all subdirectories by replacing `/tree/main/` with `/blob/main/`. This ensures direct file access on GitHub instead of folder views.

- Root README is untouched.
- All chapter and test set folders updated.
- Ensures consistency across branches.

Fixes: Broken navigation issue in GitHub UI.