### PR TITLE
Bugfix: Global README link correction for all chapters and test sets

### DIFF
--- a/C010_File_IO/README.md
+++ b/C010_File_IO/README.md
@@ -5,7 +5,7 @@
 
 ## Useful Links:
 
-- [Chapter 10 Notes](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C010_File_IO/CHAPTER_10.pdf)
+- [Chapter 10 Notes](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C010_File_IO/CHAPTER_10.pdf)
 
 *Happy Learning!*
 

--- a/C010_Test_Set/README.md
+++ b/C010_Test_Set/README.md
@@ -5,8 +5,8 @@
 
 ## Useful Links:
 
-- [Chapter 10 Test Set Notes](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C010_Test_Set/CP10_NOTES.md)
-- [Chapter 10 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C010_Test_Set/CHAPTER_10_PRACTICE_SET.pdf)
+- [Chapter 10 Test Set Notes](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C010_Test_Set/CP10_NOTES.md)
+- [Chapter 10 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C010_Test_Set/CHAPTER_10_PRACTICE_SET.pdf)
 
 *Happy Learning!*
 


### PR DESCRIPTION
This PR fixes broken links in the README.md files of all subdirectories by replacing `/tree/main/` with `/blob/main/`. This ensures direct file access on GitHub instead of folder views.

- Root README is untouched.
- All chapter and test set folders updated.
- Ensures consistency across branches.

Fixes: Broken navigation issue in GitHub UI.