### PR TITLE
Bugfix: Global README link correction for all chapters and test sets

### DIFF
--- a/C011_Dynamic_Memory/README.md
+++ b/C011_Dynamic_Memory/README.md
@@ -5,9 +5,9 @@
 
 ## Useful Links:
 
-- [Chapter 11 Notes 1](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C011_Dynamic_Memory/CHAPTER_11.pdf)
-- [Chapter 11 Notes 2](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C011_Dynamic_Memory/C11_NOTES.md)
-- [Stack Vs Heap](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C011_Dynamic_Memory/C11_STACK_VS_HEAP.png)
+- [Chapter 11 Notes 1](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C011_Dynamic_Memory/CHAPTER_11.pdf)
+- [Chapter 11 Notes 2](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C011_Dynamic_Memory/C11_NOTES.md)
+- [Stack Vs Heap](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C011_Dynamic_Memory/C11_STACK_VS_HEAP.png)
 
 *Happy Learning!*
 

--- a/C011_Test_Set/README.md
+++ b/C011_Test_Set/README.md
@@ -5,7 +5,7 @@
 
 ## Useful Links:
 
-- [Chapter 11 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/main/tree/C011_Test_Set/CHAPTER_11_PRACTICE_SET.pdf)
+- [Chapter 11 Test Set Questions](https://github.com/DipsanaRoy/learn-c-with-practice/blob/main/C011_Test_Set/CHAPTER_11_PRACTICE_SET.pdf)
 
 *Happy Learning!*
 


### PR DESCRIPTION
This PR fixes broken links in the README.md files of all subdirectories by replacing `/tree/main/` with `/blob/main/`. This ensures direct file access on GitHub instead of folder views.

- Root README is untouched.
- All chapter and test set folders updated.
- Ensures consistency across branches.

Fixes: Broken navigation issue in GitHub UI.